### PR TITLE
feat: Add Farcaster SIWF login and notification prompt

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,8 @@ import { NetworkChecker } from "@/components/network/NetworkChecker";
 import { BottomNav } from "@/components/navigation/BottomNav";
 import { AppHeader } from "@/components/navigation/AppHeader";
 import { ErrorHandler, ErrorBoundary } from "@/components/ErrorHandler";
+import { WebRedirectPrompt } from "@/components/auth/WebRedirectPrompt";
+import { NotificationPrompt } from "@/components/farcaster/NotificationPrompt";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -124,6 +126,8 @@ export default function RootLayout({
             <FarcasterProvider>
               <AppHeader />
               <NetworkChecker />
+              <WebRedirectPrompt />
+              <NotificationPrompt />
               <main className="min-h-screen pt-20 pb-20 safe-area-inset-bottom">
                 {children}
               </main>

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In - DeCleanup Rewards",
+  description: "Sign in with your Farcaster account to join the global cleanup movement.",
+};
+
+/**
+ * Login Layout
+ *
+ * This layout is minimal - it doesn't include the main app's
+ * header, bottom nav, or wallet providers since the login page
+ * handles its own authentication flow.
+ */
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { isFarcaster } from '@/lib/farcaster-detection'
+import { AuthKitProvider } from '@/components/auth/AuthKitProvider'
+import { FarcasterSignIn } from '@/components/auth/FarcasterSignIn'
+
+// Farcaster miniapp URL
+const FARCASTER_MINIAPP_URL =
+  process.env.NEXT_PUBLIC_FARCASTER_MINIAPP_URL ||
+  'https://farcaster.xyz/miniapps/SfsGBDcHpuSA/decleanup-rewards'
+
+/**
+ * Login Page
+ *
+ * This page handles Farcaster authentication for web users.
+ * - If already inside Farcaster/Warpcast, redirects to the main app
+ * - If in a regular browser, shows "Sign In With Farcaster" option
+ */
+export default function LoginPage() {
+  const router = useRouter()
+  const [environment, setEnvironment] = useState<'loading' | 'farcaster' | 'browser'>('loading')
+  const [redirectTarget, setRedirectTarget] = useState<'miniapp' | 'webapp'>('miniapp')
+
+  // Detect environment on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    // Check if we're inside Farcaster
+    const inFarcaster = isFarcaster()
+
+    if (inFarcaster) {
+      // Already in Farcaster, redirect to main app
+      setEnvironment('farcaster')
+      router.replace('/')
+    } else {
+      setEnvironment('browser')
+    }
+  }, [router])
+
+  // Loading state
+  if (environment === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="animate-pulse flex flex-col items-center gap-4">
+          <div className="w-16 h-16 rounded-full bg-brand-green/30" />
+          <div className="h-4 w-32 bg-gray-700 rounded" />
+        </div>
+      </div>
+    )
+  }
+
+  // Farcaster environment - redirecting
+  if (environment === 'farcaster') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="flex flex-col items-center gap-4">
+          <div className="animate-spin w-8 h-8 border-4 border-brand-green border-t-transparent rounded-full" />
+          <p className="text-muted-foreground">
+            Detected Farcaster environment, redirecting...
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  // Browser environment - show sign in
+  return (
+    <AuthKitProvider>
+      <div className="min-h-screen flex flex-col bg-background">
+        {/* Header */}
+        <header className="p-4 flex justify-center">
+          <div className="flex items-center gap-2">
+            <img
+              src="https://gateway.pinata.cloud/ipfs/bafkreig6ctmk5it4ppu67ljtmxjcrv2zug7rvccj5i52ji5s2qli5nww7a"
+              alt="DeCleanup Logo"
+              className="w-10 h-10 rounded-full"
+            />
+            <span className="text-xl font-bold text-foreground">
+              DeCleanup Rewards
+            </span>
+          </div>
+        </header>
+
+        {/* Main content */}
+        <main className="flex-1 flex flex-col items-center justify-center p-6">
+          <div className="max-w-md w-full bg-card border border-border rounded-2xl shadow-xl p-8">
+            {/* Hero */}
+            <div className="text-center mb-8">
+              <h1 className="text-2xl font-bold text-foreground mb-2">
+                Welcome to DeCleanup
+              </h1>
+              <p className="text-muted-foreground">
+                Sign in with your Farcaster account to join the global cleanup movement
+              </p>
+            </div>
+
+            {/* Sign in button */}
+            <div className="flex flex-col items-center gap-6">
+              <FarcasterSignIn
+                redirectTo={redirectTarget}
+                onSuccess={(data) => {
+                  console.log('[LoginPage] Auth success:', data)
+                }}
+                onError={(error) => {
+                  console.error('[LoginPage] Auth error:', error)
+                }}
+              />
+
+              {/* Redirect target toggle */}
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <span>Open in:</span>
+                <button
+                  onClick={() => setRedirectTarget('miniapp')}
+                  className={`px-3 py-1 rounded-full transition-colors ${
+                    redirectTarget === 'miniapp'
+                      ? 'bg-brand-green/20 text-brand-green'
+                      : 'hover:bg-muted'
+                  }`}
+                >
+                  Farcaster
+                </button>
+                <button
+                  onClick={() => setRedirectTarget('webapp')}
+                  className={`px-3 py-1 rounded-full transition-colors ${
+                    redirectTarget === 'webapp'
+                      ? 'bg-brand-green/20 text-brand-green'
+                      : 'hover:bg-muted'
+                  }`}
+                >
+                  Web App
+                </button>
+              </div>
+            </div>
+
+            {/* Divider */}
+            <div className="my-8 flex items-center gap-4">
+              <div className="flex-1 h-px bg-border" />
+              <span className="text-sm text-muted-foreground">or</span>
+              <div className="flex-1 h-px bg-border" />
+            </div>
+
+            {/* Alternative options */}
+            <div className="flex flex-col gap-3">
+              <a
+                href={FARCASTER_MINIAPP_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-2 px-4 py-3 bg-muted hover:bg-muted/80 rounded-lg text-foreground font-medium transition-colors"
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+                Open in Warpcast
+              </a>
+
+              <button
+                onClick={() => router.push('/')}
+                className="flex items-center justify-center gap-2 px-4 py-3 border border-border hover:bg-muted rounded-lg text-muted-foreground font-medium transition-colors"
+              >
+                Continue as Guest
+              </button>
+            </div>
+          </div>
+
+          {/* Info text */}
+          <p className="mt-6 text-sm text-muted-foreground text-center max-w-sm">
+            Sign in with Farcaster to earn rewards, track your cleanups, and connect with the community.
+          </p>
+        </main>
+
+        {/* Footer */}
+        <footer className="p-4 text-center text-sm text-muted-foreground">
+          <p>Clean up, snap, earn. Powered by Base.</p>
+        </footer>
+      </div>
+    </AuthKitProvider>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import { getUserCleanupStatus } from '@/lib/verification'
 import { claimImpactProductFromVerification, getClaimFee, getUserLevel } from '@/lib/contracts'
 import { isFarcasterContext } from '@/lib/farcaster'
 import { REQUIRED_BLOCK_EXPLORER_URL } from '@/lib/wagmi'
+import { SmartWalletConnect } from '@/components/auth/SmartWalletConnect'
 
 const BLOCK_EXPLORER_NAME = REQUIRED_BLOCK_EXPLORER_URL.includes('sepolia')
   ? 'Basescan (Sepolia)'
@@ -496,25 +497,11 @@ export default function Home() {
               </div>
             </div>
           ) : (
-            <div className="mx-auto max-w-md space-y-4">
-              <div>
-                <p className="mb-3 text-xs text-muted-foreground">
-                  Connect your wallet to get started.
-                </p>
-                <Button
-                  size="lg"
-                  className="w-full gap-2 bg-brand-green text-black hover:bg-[#4a9a26]"
-                  disabled={isPending || !primaryConnector}
-                  onClick={() => handleConnect(primaryConnector)}
-                >
-                  <Wallet className="h-5 w-5" />
-                  {isPending ? 'Connecting...' : 'Log In'}
-                </Button>
-                <p className="mt-2 text-xs text-muted-foreground text-center">
-                  Use, when on Farcaster. Connects you with FC wallet
-                </p>
-              </div>
-            </div>
+            <SmartWalletConnect
+              onConnect={(address) => {
+                console.log('[Home] Wallet connected:', address)
+              }}
+            />
           )}
         </section>
 

--- a/components/auth/AuthKitProvider.tsx
+++ b/components/auth/AuthKitProvider.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { AuthKitProvider as FarcasterAuthKitProvider } from '@farcaster/auth-kit'
+import { ReactNode } from 'react'
+
+// AuthKit configuration for Sign In With Farcaster (SIWF)
+// This is separate from the miniapp SDK - it's for web-based authentication
+const authKitConfig = {
+  // Farcaster relay for authentication
+  relay: 'https://relay.farcaster.xyz',
+  // Optimism Mainnet RPC (Farcaster uses Optimism for identity)
+  rpcUrl: process.env.NEXT_PUBLIC_AUTHKIT_RPC_URL || 'https://mainnet.optimism.io',
+  // Domain must match where the app is hosted
+  domain: process.env.NEXT_PUBLIC_APP_DOMAIN || 'localhost:3000',
+  // SIWE URI for the authentication request
+  siweUri: process.env.NEXT_PUBLIC_SIWE_URI || 'http://localhost:3000/login',
+}
+
+interface AuthKitProviderProps {
+  children: ReactNode
+}
+
+/**
+ * AuthKit Provider for Sign In With Farcaster (SIWF)
+ *
+ * This enables web users to authenticate using their Farcaster account
+ * via QR code scanning in Warpcast. After authentication, users can be
+ * redirected to the Farcaster miniapp.
+ *
+ * Note: This is different from the miniapp SDK which is used when
+ * the app is already running inside Farcaster/Warpcast.
+ */
+export function AuthKitProvider({ children }: AuthKitProviderProps) {
+  return (
+    <FarcasterAuthKitProvider config={authKitConfig}>
+      {children}
+    </FarcasterAuthKitProvider>
+  )
+}
+
+export default AuthKitProvider

--- a/components/auth/FarcasterLoginBanner.tsx
+++ b/components/auth/FarcasterLoginBanner.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { isFarcaster } from '@/lib/farcaster-detection'
+import { useAccount } from 'wagmi'
+
+/**
+ * Farcaster Login Banner
+ *
+ * Shows a banner prompting users to sign in with Farcaster
+ * when they are:
+ * - Not in the Farcaster environment (regular browser)
+ * - Not connected with a wallet
+ *
+ * Hidden when:
+ * - User is inside Farcaster/Warpcast
+ * - User has connected a wallet
+ * - User has dismissed the banner
+ */
+export function FarcasterLoginBanner() {
+  const [isVisible, setIsVisible] = useState(false)
+  const [isDismissed, setIsDismissed] = useState(false)
+  const { isConnected } = useAccount()
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    // Check if already dismissed in this session
+    const dismissed = sessionStorage.getItem('fc-login-banner-dismissed')
+    if (dismissed) {
+      setIsDismissed(true)
+      return
+    }
+
+    // Check if in Farcaster environment
+    const inFarcaster = isFarcaster()
+
+    // Show banner if not in Farcaster and not connected
+    setIsVisible(!inFarcaster && !isConnected)
+  }, [isConnected])
+
+  const handleDismiss = () => {
+    setIsDismissed(true)
+    sessionStorage.setItem('fc-login-banner-dismissed', 'true')
+  }
+
+  if (!isVisible || isDismissed) return null
+
+  return (
+    <div className="fixed top-24 sm:top-28 left-0 right-0 z-40 px-4">
+      <div className="max-w-lg mx-auto bg-gradient-to-r from-brand-green to-[#4a9a26] rounded-xl shadow-lg p-3 sm:p-4">
+        <div className="flex items-center gap-3">
+          {/* Farcaster Icon */}
+          <div className="flex-shrink-0 w-9 h-9 sm:w-10 sm:h-10 bg-black/20 rounded-full flex items-center justify-center">
+            <svg
+              className="w-5 h-5 sm:w-6 sm:h-6 text-white"
+              viewBox="0 0 1000 1000"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M257.778 155.556H742.222V844.444H671.111V528.889H670.414C662.554 441.677 589.258 373.333 500 373.333C410.742 373.333 337.446 441.677 329.586 528.889H328.889V844.444H257.778V155.556Z"
+                fill="currentColor"
+              />
+              <path
+                d="M128.889 253.333L157.778 351.111H182.222V746.667C169.949 746.667 160 756.616 160 768.889V795.556H155.556C143.283 795.556 133.333 805.505 133.333 817.778V844.444H382.222V817.778C382.222 805.505 372.273 795.556 360 795.556H355.556V768.889C355.556 756.616 345.606 746.667 333.333 746.667H306.667V253.333H128.889Z"
+                fill="currentColor"
+              />
+              <path
+                d="M675.556 746.667C663.283 746.667 653.333 756.616 653.333 768.889V795.556H648.889C636.616 795.556 626.667 805.505 626.667 817.778V844.444H875.556V817.778C875.556 805.505 865.606 795.556 853.333 795.556H848.889V768.889C848.889 756.616 838.94 746.667 826.667 746.667V351.111H851.111L880 253.333H702.222V746.667H675.556Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            <p className="text-black font-medium text-sm">
+              Have a Farcaster account?
+            </p>
+            <p className="text-black/70 text-xs">
+              Sign in for seamless rewards tracking
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <Link
+              href="/login"
+              className="px-3 py-1.5 bg-black text-brand-green rounded-lg text-sm font-medium hover:bg-gray-900 transition-colors"
+            >
+              Log In
+            </Link>
+            <button
+              onClick={handleDismiss}
+              className="p-1 text-black/50 hover:text-black transition-colors"
+              aria-label="Dismiss"
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default FarcasterLoginBanner

--- a/components/auth/FarcasterSignIn.tsx
+++ b/components/auth/FarcasterSignIn.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useSignIn, useProfile, StatusAPIResponse, AuthClientError } from '@farcaster/auth-kit'
+import '@farcaster/auth-kit/styles.css'
+
+// Farcaster miniapp URL for redirect after authentication
+const FARCASTER_MINIAPP_URL =
+  process.env.NEXT_PUBLIC_FARCASTER_MINIAPP_URL ||
+  'https://farcaster.xyz/miniapps/SfsGBDcHpuSA/decleanup-rewards'
+
+// Web app URL fallback
+const WEB_APP_URL =
+  process.env.NEXT_PUBLIC_MINIAPP_URL || 'https://miniapp.decleanup.net'
+
+interface FarcasterSignInProps {
+  /** Where to redirect after successful authentication */
+  redirectTo?: 'miniapp' | 'webapp' | 'none'
+  /** Custom redirect URL (overrides redirectTo) */
+  customRedirectUrl?: string
+  /** Callback when authentication succeeds */
+  onSuccess?: (data: StatusAPIResponse) => void
+  /** Callback when authentication fails */
+  onError?: (error?: AuthClientError) => void
+  /** Show compact button style */
+  compact?: boolean
+}
+
+/**
+ * Farcaster Sign In Button Component
+ *
+ * Provides "Sign In With Farcaster" functionality for web users.
+ * After successful authentication, can redirect to:
+ * - Farcaster miniapp (default)
+ * - Web app
+ * - Custom URL
+ * - No redirect (handle in onSuccess callback)
+ */
+export function FarcasterSignIn({
+  redirectTo = 'miniapp',
+  customRedirectUrl,
+  onSuccess,
+  onError,
+  compact = false,
+}: FarcasterSignInProps) {
+  const [isRedirecting, setIsRedirecting] = useState(false)
+
+  const handleSuccess = useCallback(
+    (data: StatusAPIResponse) => {
+      // Call custom success handler if provided
+      onSuccess?.(data)
+
+      // Determine redirect URL
+      let redirectUrl: string | null = null
+
+      if (customRedirectUrl) {
+        redirectUrl = customRedirectUrl
+      } else if (redirectTo === 'miniapp') {
+        // Redirect to Farcaster miniapp with custody address as ref
+        const custodyAddress = data.custody
+        redirectUrl = custodyAddress
+          ? `${FARCASTER_MINIAPP_URL}?ref=${custodyAddress}`
+          : FARCASTER_MINIAPP_URL
+      } else if (redirectTo === 'webapp') {
+        // Redirect to web app with custody address as ref
+        const custodyAddress = data.custody
+        redirectUrl = custodyAddress
+          ? `${WEB_APP_URL}?ref=${custodyAddress}`
+          : WEB_APP_URL
+      }
+
+      // Perform redirect if URL is set
+      if (redirectUrl) {
+        setIsRedirecting(true)
+        // Small delay to show success state
+        setTimeout(() => {
+          window.location.href = redirectUrl!
+        }, 500)
+      }
+    },
+    [redirectTo, customRedirectUrl, onSuccess]
+  )
+
+  const handleError = useCallback(
+    (error?: AuthClientError) => {
+      console.error('[FarcasterSignIn] Authentication error:', error)
+      onError?.(error)
+    },
+    [onError]
+  )
+
+  const {
+    signIn,
+    signOut,
+    connect,
+    reconnect,
+    isSuccess,
+    isError,
+    error,
+    channelToken,
+    url,
+    data,
+    validSignature,
+  } = useSignIn({
+    onSuccess: handleSuccess,
+    onError: handleError,
+  })
+
+  const { isAuthenticated, profile } = useProfile()
+
+  // Handle sign in click
+  const handleSignIn = useCallback(async () => {
+    console.log('[FarcasterSignIn] Button clicked, isAuthenticated:', isAuthenticated)
+    if (isAuthenticated) {
+      // Already authenticated, redirect directly
+      console.log('[FarcasterSignIn] Already authenticated, redirecting...')
+      if (profile?.custody) {
+        handleSuccess({ custody: profile.custody } as StatusAPIResponse)
+      }
+    } else {
+      console.log('[FarcasterSignIn] Starting sign in flow...')
+      try {
+        // First connect to create a channel, then sign in
+        if (!channelToken) {
+          console.log('[FarcasterSignIn] No channel token, calling connect()...')
+          await connect()
+        }
+        console.log('[FarcasterSignIn] Calling signIn()...')
+        await signIn()
+        console.log('[FarcasterSignIn] signIn() called successfully')
+      } catch (err) {
+        console.error('[FarcasterSignIn] signIn() error:', err)
+      }
+    }
+  }, [isAuthenticated, profile, signIn, connect, channelToken, handleSuccess])
+
+  // Log state changes for debugging
+  useEffect(() => {
+    console.log('[FarcasterSignIn] State:', { url, isSuccess, isError, channelToken })
+  }, [url, isSuccess, isError, channelToken])
+
+  // If already authenticated on mount, show profile info
+  if (isAuthenticated && profile) {
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <div className="flex items-center gap-3 p-3 bg-brand-green/10 rounded-lg border border-brand-green/30">
+          {profile.pfpUrl && (
+            <img
+              src={profile.pfpUrl}
+              alt={profile.displayName || profile.username || 'Profile'}
+              className="w-10 h-10 rounded-full"
+            />
+          )}
+          <div>
+            <p className="font-medium text-brand-green">
+              {profile.displayName || profile.username}
+            </p>
+            {profile.username && (
+              <p className="text-sm text-brand-green/70">
+                @{profile.username}
+              </p>
+            )}
+          </div>
+        </div>
+        {isRedirecting ? (
+          <p className="text-sm text-muted-foreground">Redirecting to app...</p>
+        ) : (
+          <div className="flex gap-2">
+            <button
+              onClick={() => handleSuccess({ custody: profile.custody } as StatusAPIResponse)}
+              className="px-4 py-2 bg-brand-green hover:bg-[#4a9a26] text-black rounded-lg text-sm font-medium transition-colors"
+            >
+              Open DeCleanup
+            </button>
+            <button
+              onClick={() => signOut()}
+              className="px-4 py-2 bg-muted hover:bg-muted/80 text-foreground rounded-lg text-sm font-medium transition-colors"
+            >
+              Sign Out
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Show QR code if channel is active
+  if (url && !isSuccess) {
+    return (
+      <div className="flex flex-col items-center gap-4">
+        <p className="text-sm text-muted-foreground">
+          Scan with Warpcast to sign in
+        </p>
+        <div className="p-4 bg-white rounded-lg shadow-lg">
+          {/* QR code is rendered by AuthKit internally */}
+          <img
+            src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(url)}`}
+            alt="Sign in with Farcaster QR code"
+            className="w-48 h-48"
+          />
+        </div>
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-brand-green hover:text-[#4a9a26] underline"
+        >
+          Open in Warpcast
+        </a>
+      </div>
+    )
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <p className="text-sm text-red-500">
+          Sign in failed{error?.message ? `: ${error.message}` : ''}
+        </p>
+        <button
+          onClick={handleSignIn}
+          className="px-6 py-3 bg-brand-green hover:bg-[#4a9a26] text-black rounded-lg font-medium transition-colors"
+        >
+          Try Again
+        </button>
+      </div>
+    )
+  }
+
+  // Default sign in button
+  return (
+    <button
+      onClick={handleSignIn}
+      className={`
+        flex items-center justify-center gap-2
+        bg-brand-green hover:bg-[#4a9a26]
+        text-black font-medium rounded-lg
+        transition-colors
+        ${compact ? 'px-4 py-2 text-sm' : 'px-6 py-3 text-base'}
+      `}
+    >
+      <FarcasterIcon className={compact ? 'w-4 h-4' : 'w-5 h-5'} />
+      Sign in with Farcaster
+    </button>
+  )
+}
+
+// Farcaster icon component
+function FarcasterIcon({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 1000 1000"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M257.778 155.556H742.222V844.444H671.111V528.889H670.414C662.554 441.677 589.258 373.333 500 373.333C410.742 373.333 337.446 441.677 329.586 528.889H328.889V844.444H257.778V155.556Z"
+        fill="currentColor"
+      />
+      <path
+        d="M128.889 253.333L157.778 351.111H182.222V746.667C169.949 746.667 160 756.616 160 768.889V795.556H155.556C143.283 795.556 133.333 805.505 133.333 817.778V844.444H382.222V817.778C382.222 805.505 372.273 795.556 360 795.556H355.556V768.889C355.556 756.616 345.606 746.667 333.333 746.667H306.667V253.333H128.889Z"
+        fill="currentColor"
+      />
+      <path
+        d="M675.556 746.667C663.283 746.667 653.333 756.616 653.333 768.889V795.556H648.889C636.616 795.556 626.667 805.505 626.667 817.778V844.444H875.556V817.778C875.556 805.505 865.606 795.556 853.333 795.556H848.889V768.889C848.889 756.616 838.94 746.667 826.667 746.667V351.111H851.111L880 253.333H702.222V746.667H675.556Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+export default FarcasterSignIn

--- a/components/auth/SmartWalletConnect.tsx
+++ b/components/auth/SmartWalletConnect.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { ConnectButton } from '@rainbow-me/rainbowkit'
+import { useAccount } from 'wagmi'
+import { useSignIn } from '@farcaster/auth-kit'
+import { isFarcaster } from '@/lib/farcaster-detection'
+import { Button } from '@/components/ui/button'
+import { Wallet, X } from 'lucide-react'
+import { AuthKitProvider } from './AuthKitProvider'
+
+interface SmartWalletConnectProps {
+  /** Called when successfully connected */
+  onConnect?: (address: string) => void
+  /** Custom button text */
+  buttonText?: string
+}
+
+// Farcaster miniapp URL for redirect after authentication
+const FARCASTER_MINIAPP_URL =
+  process.env.NEXT_PUBLIC_FARCASTER_MINIAPP_URL ||
+  'https://farcaster.xyz/miniapps/SfsGBDcHpuSA/decleanup-rewards'
+
+/**
+ * Smart Wallet Connect Component
+ *
+ * Shows a single "Log In" button that opens a modal with:
+ * - Sign in with Farcaster (SIWF) option for web users
+ * - Standard wallet options via RainbowKit
+ */
+export function SmartWalletConnect({
+  onConnect,
+  buttonText = 'Log In',
+}: SmartWalletConnectProps) {
+  const [mounted, setMounted] = useState(false)
+  const [showModal, setShowModal] = useState(false)
+  const [isInFarcaster, setIsInFarcaster] = useState(false)
+  const { address, isConnected } = useAccount()
+
+  useEffect(() => {
+    setMounted(true)
+    setIsInFarcaster(isFarcaster())
+  }, [])
+
+  useEffect(() => {
+    if (isConnected && address) {
+      onConnect?.(address)
+      setShowModal(false)
+    }
+  }, [isConnected, address, onConnect])
+
+  if (!mounted) {
+    return (
+      <div className="mx-auto max-w-md">
+        <Button size="lg" disabled className="w-full gap-2 bg-brand-green text-black">
+          <Wallet className="h-5 w-5" />
+          {buttonText}
+        </Button>
+      </div>
+    )
+  }
+
+  if (isConnected) {
+    return null
+  }
+
+  return (
+    <>
+      <div className="mx-auto max-w-md">
+        <Button
+          size="lg"
+          onClick={() => setShowModal(true)}
+          className="w-full gap-2 bg-brand-green text-black hover:bg-[#4a9a26]"
+        >
+          <Wallet className="h-5 w-5" />
+          {buttonText}
+        </Button>
+        <p className="mt-3 text-xs text-muted-foreground text-center">
+          Connect to get started
+        </p>
+      </div>
+
+      {/* Login Modal */}
+      {showModal && (
+        <AuthKitProvider>
+          <LoginModal
+            isInFarcaster={isInFarcaster}
+            onClose={() => setShowModal(false)}
+          />
+        </AuthKitProvider>
+      )}
+    </>
+  )
+}
+
+// Separate modal component that uses AuthKit hooks
+function LoginModal({
+  isInFarcaster,
+  onClose,
+}: {
+  isInFarcaster: boolean
+  onClose: () => void
+}) {
+  const [showQR, setShowQR] = useState(false)
+
+  const {
+    signIn,
+    connect,
+    url,
+    isSuccess,
+    isError,
+    error,
+    channelToken,
+  } = useSignIn({
+    onSuccess: (data) => {
+      console.log('[LoginModal] SIWF success:', data)
+      // Redirect to Farcaster miniapp after successful auth
+      const redirectUrl = data.custody
+        ? `${FARCASTER_MINIAPP_URL}?ref=${data.custody}`
+        : FARCASTER_MINIAPP_URL
+      window.location.href = redirectUrl
+    },
+    onError: (err) => {
+      console.error('[LoginModal] SIWF error:', err)
+    },
+  })
+
+  const handleFarcasterLogin = useCallback(async () => {
+    console.log('[LoginModal] Starting Farcaster login...')
+    try {
+      if (!channelToken) {
+        await connect()
+      }
+      await signIn()
+      setShowQR(true)
+    } catch (err) {
+      console.error('[LoginModal] Error:', err)
+    }
+  }, [connect, signIn, channelToken])
+
+  // Show QR code if URL is available
+  if (showQR && url && !isSuccess) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+        <div className="relative max-w-sm w-full bg-card border border-border rounded-2xl shadow-2xl p-6">
+          <button
+            onClick={() => { setShowQR(false); onClose(); }}
+            className="absolute top-4 right-4 p-1 text-muted-foreground hover:text-foreground"
+          >
+            <X className="w-5 h-5" />
+          </button>
+
+          <div className="text-center mb-4">
+            <h2 className="text-lg font-bold text-foreground">Scan with Warpcast</h2>
+            <p className="text-sm text-muted-foreground">
+              Open Warpcast and scan this QR code
+            </p>
+          </div>
+
+          <div className="flex justify-center mb-4">
+            <div className="p-4 bg-white rounded-xl">
+              <img
+                src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(url)}`}
+                alt="Sign in with Farcaster"
+                className="w-48 h-48"
+              />
+            </div>
+          </div>
+
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block w-full py-3 text-center bg-brand-green hover:bg-[#4a9a26] text-black font-medium rounded-xl transition-colors"
+          >
+            Open in Warpcast
+          </a>
+        </div>
+      </div>
+    )
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+        <div className="relative max-w-sm w-full bg-card border border-border rounded-2xl shadow-2xl p-6">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 p-1 text-muted-foreground hover:text-foreground"
+          >
+            <X className="w-5 h-5" />
+          </button>
+          <p className="text-center text-red-500 mb-4">
+            Sign in failed{error?.message ? `: ${error.message}` : ''}
+          </p>
+          <button
+            onClick={handleFarcasterLogin}
+            className="w-full py-3 bg-brand-green hover:bg-[#4a9a26] text-black font-medium rounded-xl"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // Main modal with options
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+      <div className="relative max-w-sm w-full bg-card border border-border rounded-2xl shadow-2xl p-6">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 p-1 text-muted-foreground hover:text-foreground"
+        >
+          <X className="w-5 h-5" />
+        </button>
+
+        <div className="text-center mb-6">
+          <h2 className="text-lg font-bold text-foreground">Connect</h2>
+          <p className="text-sm text-muted-foreground">
+            Choose how to connect
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          {/* Farcaster option - only show on web */}
+          {!isInFarcaster && (
+            <button
+              onClick={handleFarcasterLogin}
+              className="w-full flex items-center gap-3 p-4 bg-[#855DCD] hover:bg-[#7349b8] text-white rounded-xl transition-colors"
+            >
+              <div className="w-10 h-10 bg-white/20 rounded-lg flex items-center justify-center">
+                <FarcasterIcon className="w-6 h-6" />
+              </div>
+              <div className="text-left">
+                <p className="font-medium">Sign in with Farcaster</p>
+                <p className="text-xs text-white/70">Scan QR with Warpcast</p>
+              </div>
+            </button>
+          )}
+
+          {/* Wallet options via RainbowKit */}
+          <ConnectButton.Custom>
+            {({ openConnectModal, mounted: rkMounted }) => {
+              const ready = rkMounted
+              return (
+                <button
+                  onClick={() => { onClose(); openConnectModal(); }}
+                  disabled={!ready}
+                  className="w-full flex items-center gap-3 p-4 bg-muted hover:bg-muted/80 text-foreground rounded-xl transition-colors"
+                >
+                  <div className="w-10 h-10 bg-brand-green/20 rounded-lg flex items-center justify-center">
+                    <Wallet className="w-6 h-6 text-brand-green" />
+                  </div>
+                  <div className="text-left">
+                    <p className="font-medium">Connect Wallet</p>
+                    <p className="text-xs text-muted-foreground">MetaMask, WalletConnect, etc.</p>
+                  </div>
+                </button>
+              )
+            }}
+          </ConnectButton.Custom>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Farcaster icon
+function FarcasterIcon({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 1000 1000" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M257.778 155.556H742.222V844.444H671.111V528.889H670.414C662.554 441.677 589.258 373.333 500 373.333C410.742 373.333 337.446 441.677 329.586 528.889H328.889V844.444H257.778V155.556Z" fill="currentColor"/>
+      <path d="M128.889 253.333L157.778 351.111H182.222V746.667C169.949 746.667 160 756.616 160 768.889V795.556H155.556C143.283 795.556 133.333 805.505 133.333 817.778V844.444H382.222V817.778C382.222 805.505 372.273 795.556 360 795.556H355.556V768.889C355.556 756.616 345.606 746.667 333.333 746.667H306.667V253.333H128.889Z" fill="currentColor"/>
+      <path d="M675.556 746.667C663.283 746.667 653.333 756.616 653.333 768.889V795.556H648.889C636.616 795.556 626.667 805.505 626.667 817.778V844.444H875.556V817.778C875.556 805.505 865.606 795.556 853.333 795.556H848.889V768.889C848.889 756.616 838.94 746.667 826.667 746.667V351.111H851.111L880 253.333H702.222V746.667H675.556Z" fill="currentColor"/>
+    </svg>
+  )
+}
+
+export default SmartWalletConnect

--- a/components/auth/WebRedirectPrompt.tsx
+++ b/components/auth/WebRedirectPrompt.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { isFarcaster } from '@/lib/farcaster-detection'
+import { X } from 'lucide-react'
+
+const FARCASTER_MINIAPP_URL =
+  process.env.NEXT_PUBLIC_FARCASTER_MINIAPP_URL ||
+  'https://farcaster.xyz/miniapps/SfsGBDcHpuSA/decleanup-rewards'
+
+/**
+ * Web Redirect Prompt
+ *
+ * Shows a modal on web (not in Farcaster) asking if user wants
+ * to be redirected to the Farcaster miniapp for the best experience.
+ *
+ * Only shows once per session.
+ */
+export function WebRedirectPrompt() {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    // Check if already dismissed in this session
+    const dismissed = sessionStorage.getItem('web-redirect-prompt-dismissed')
+    if (dismissed) return
+
+    // Check if in Farcaster environment - don't show if already there
+    const inFarcaster = isFarcaster()
+    if (inFarcaster) return
+
+    // Show prompt after a short delay
+    const timer = setTimeout(() => {
+      setIsVisible(true)
+    }, 1000)
+
+    return () => clearTimeout(timer)
+  }, [])
+
+  const handleDismiss = () => {
+    setIsVisible(false)
+    sessionStorage.setItem('web-redirect-prompt-dismissed', 'true')
+  }
+
+  const handleRedirect = () => {
+    sessionStorage.setItem('web-redirect-prompt-dismissed', 'true')
+    window.location.href = FARCASTER_MINIAPP_URL
+  }
+
+  if (!isVisible) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm animate-in fade-in duration-200">
+      <div className="relative max-w-sm w-full bg-card border border-border rounded-2xl shadow-2xl p-6 animate-in zoom-in-95 duration-200">
+        {/* Close button */}
+        <button
+          onClick={handleDismiss}
+          className="absolute top-4 right-4 p-1 text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Close"
+        >
+          <X className="w-5 h-5" />
+        </button>
+
+        {/* Farcaster icon */}
+        <div className="flex justify-center mb-4">
+          <div className="w-16 h-16 bg-brand-green/20 rounded-full flex items-center justify-center">
+            <svg
+              className="w-8 h-8 text-brand-green"
+              viewBox="0 0 1000 1000"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M257.778 155.556H742.222V844.444H671.111V528.889H670.414C662.554 441.677 589.258 373.333 500 373.333C410.742 373.333 337.446 441.677 329.586 528.889H328.889V844.444H257.778V155.556Z"
+                fill="currentColor"
+              />
+              <path
+                d="M128.889 253.333L157.778 351.111H182.222V746.667C169.949 746.667 160 756.616 160 768.889V795.556H155.556C143.283 795.556 133.333 805.505 133.333 817.778V844.444H382.222V817.778C382.222 805.505 372.273 795.556 360 795.556H355.556V768.889C355.556 756.616 345.606 746.667 333.333 746.667H306.667V253.333H128.889Z"
+                fill="currentColor"
+              />
+              <path
+                d="M675.556 746.667C663.283 746.667 653.333 756.616 653.333 768.889V795.556H648.889C636.616 795.556 626.667 805.505 626.667 817.778V844.444H875.556V817.778C875.556 805.505 865.606 795.556 853.333 795.556H848.889V768.889C848.889 756.616 838.94 746.667 826.667 746.667V351.111H851.111L880 253.333H702.222V746.667H675.556Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="text-center mb-6">
+          <h2 className="text-lg font-bold text-foreground mb-2">
+            Open in Farcaster?
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            For the best experience, open DeCleanup Rewards in the Farcaster app.
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={handleRedirect}
+            className="w-full py-3 bg-brand-green hover:bg-[#4a9a26] text-black font-medium rounded-xl transition-colors"
+          >
+            Open in Farcaster
+          </button>
+          <button
+            onClick={handleDismiss}
+            className="w-full py-3 bg-muted hover:bg-muted/80 text-foreground font-medium rounded-xl transition-colors"
+          >
+            Continue on Web
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default WebRedirectPrompt

--- a/components/auth/index.ts
+++ b/components/auth/index.ts
@@ -1,0 +1,5 @@
+// Auth components for Farcaster Sign In With Farcaster (SIWF)
+export { AuthKitProvider } from './AuthKitProvider'
+export { FarcasterSignIn } from './FarcasterSignIn'
+export { SmartWalletConnect } from './SmartWalletConnect'
+export { WebRedirectPrompt } from './WebRedirectPrompt'

--- a/components/farcaster/NotificationPrompt.tsx
+++ b/components/farcaster/NotificationPrompt.tsx
@@ -1,0 +1,251 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { sdk } from '@farcaster/miniapp-sdk'
+import { isFarcaster } from '@/lib/farcaster-detection'
+import { Bell, X, Check, Loader2 } from 'lucide-react'
+
+const NOTIFICATION_PROMPT_KEY = 'decleanup_notification_prompt_shown'
+const NOTIFICATION_ENABLED_KEY = 'decleanup_notifications_enabled'
+
+/**
+ * NotificationPrompt - Prompts users to enable app notifications in Farcaster
+ *
+ * Uses sdk.actions.addFrame() which:
+ * 1. Adds the app to user's favorites
+ * 2. Enables push notifications
+ * 3. Returns notification token for server-side notifications
+ *
+ * Only shows in Farcaster context, once per session
+ */
+export function NotificationPrompt() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isInFarcaster, setIsInFarcaster] = useState(false)
+
+  useEffect(() => {
+    // Only run on client
+    if (typeof window === 'undefined') return
+
+    // Check if in Farcaster
+    const inFarcaster = isFarcaster()
+    setIsInFarcaster(inFarcaster)
+
+    if (!inFarcaster) {
+      console.log('[NotificationPrompt] Not in Farcaster, skipping')
+      return
+    }
+
+    // Check if already shown this session
+    const alreadyShown = sessionStorage.getItem(NOTIFICATION_PROMPT_KEY)
+    if (alreadyShown) {
+      console.log('[NotificationPrompt] Already shown this session')
+      return
+    }
+
+    // Check if notifications already enabled (persisted)
+    const notificationsEnabled = localStorage.getItem(NOTIFICATION_ENABLED_KEY)
+    if (notificationsEnabled === 'true') {
+      console.log('[NotificationPrompt] Notifications already enabled')
+      return
+    }
+
+    // Check if app is already added via SDK context
+    const checkIfAdded = async () => {
+      try {
+        const context = await sdk.context
+        if (context?.client?.added) {
+          console.log('[NotificationPrompt] App already added by user')
+          localStorage.setItem(NOTIFICATION_ENABLED_KEY, 'true')
+          return
+        }
+      } catch (err) {
+        console.log('[NotificationPrompt] Could not check context:', err)
+      }
+
+      // Show prompt after a short delay for better UX
+      setTimeout(() => {
+        setIsOpen(true)
+        sessionStorage.setItem(NOTIFICATION_PROMPT_KEY, 'true')
+      }, 2000)
+    }
+
+    checkIfAdded()
+  }, [])
+
+  const handleEnableNotifications = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      console.log('[NotificationPrompt] Requesting addFrame...')
+
+      if (!sdk.actions || typeof sdk.actions.addFrame !== 'function') {
+        throw new Error('addFrame not available')
+      }
+
+      const result = await sdk.actions.addFrame()
+
+      console.log('[NotificationPrompt] addFrame result:', result)
+
+      if (result.added) {
+        // Success - app was added and notifications enabled
+        setIsSuccess(true)
+        localStorage.setItem(NOTIFICATION_ENABLED_KEY, 'true')
+
+        // Store notification details if provided (for server-side notifications)
+        if (result.notificationDetails) {
+          try {
+            localStorage.setItem(
+              'decleanup_notification_details',
+              JSON.stringify(result.notificationDetails)
+            )
+            console.log('[NotificationPrompt] Notification details saved:', result.notificationDetails)
+          } catch (e) {
+            console.warn('[NotificationPrompt] Could not save notification details')
+          }
+        }
+
+        // Close after showing success
+        setTimeout(() => {
+          setIsOpen(false)
+        }, 2000)
+      } else {
+        // User rejected
+        console.log('[NotificationPrompt] User rejected addFrame')
+        setError('You can enable notifications later from settings')
+        setTimeout(() => {
+          setIsOpen(false)
+        }, 2000)
+      }
+    } catch (err: any) {
+      console.error('[NotificationPrompt] Error:', err)
+
+      if (err?.message?.includes('rejected_by_user')) {
+        setError('You can enable notifications later from settings')
+      } else {
+        setError('Could not enable notifications. Try again later.')
+      }
+
+      setTimeout(() => {
+        setIsOpen(false)
+      }, 3000)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  const handleDismiss = useCallback(() => {
+    setIsOpen(false)
+    // Mark as shown so we don't show again this session
+    sessionStorage.setItem(NOTIFICATION_PROMPT_KEY, 'true')
+  }, [])
+
+  // Don't render if not in Farcaster or not open
+  if (!isInFarcaster || !isOpen) {
+    return null
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+      <div className="relative max-w-sm w-full bg-card border border-border rounded-2xl shadow-2xl p-6 animate-in fade-in slide-in-from-bottom-4 duration-300">
+        {/* Close button */}
+        <button
+          onClick={handleDismiss}
+          className="absolute top-4 right-4 p-1 text-muted-foreground hover:text-foreground transition-colors"
+          disabled={isLoading}
+        >
+          <X className="w-5 h-5" />
+        </button>
+
+        {/* Icon */}
+        <div className="flex justify-center mb-4">
+          <div className={`w-16 h-16 rounded-full flex items-center justify-center ${
+            isSuccess
+              ? 'bg-brand-green/20'
+              : error
+                ? 'bg-red-500/20'
+                : 'bg-brand-green/20'
+          }`}>
+            {isSuccess ? (
+              <Check className="w-8 h-8 text-brand-green" />
+            ) : error ? (
+              <X className="w-8 h-8 text-red-500" />
+            ) : isLoading ? (
+              <Loader2 className="w-8 h-8 text-brand-green animate-spin" />
+            ) : (
+              <Bell className="w-8 h-8 text-brand-green" />
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="text-center mb-6">
+          {isSuccess ? (
+            <>
+              <h2 className="text-lg font-bold text-foreground mb-2">
+                Notifications Enabled!
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                You'll receive updates about your cleanups and rewards
+              </p>
+            </>
+          ) : error ? (
+            <>
+              <h2 className="text-lg font-bold text-foreground mb-2">
+                No Problem
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {error}
+              </p>
+            </>
+          ) : (
+            <>
+              <h2 className="text-lg font-bold text-foreground mb-2">
+                Stay Updated
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Enable notifications to get updates on your cleanups, rewards, and community activity
+              </p>
+            </>
+          )}
+        </div>
+
+        {/* Actions */}
+        {!isSuccess && !error && (
+          <div className="space-y-3">
+            <button
+              onClick={handleEnableNotifications}
+              disabled={isLoading}
+              className="w-full flex items-center justify-center gap-2 py-3 px-4 bg-brand-green hover:bg-[#4a9a26] text-black font-medium rounded-xl transition-colors disabled:opacity-50"
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                  Enabling...
+                </>
+              ) : (
+                <>
+                  <Bell className="w-5 h-5" />
+                  Enable Notifications
+                </>
+              )}
+            </button>
+
+            <button
+              onClick={handleDismiss}
+              disabled={isLoading}
+              className="w-full py-3 px-4 text-muted-foreground hover:text-foreground font-medium rounded-xl transition-colors disabled:opacity-50"
+            >
+              Maybe Later
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default NotificationPrompt

--- a/components/network/NetworkChecker.tsx
+++ b/components/network/NetworkChecker.tsx
@@ -1,43 +1,144 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { useAccount, useChainId } from 'wagmi'
-import { AlertCircle } from 'lucide-react'
+import { useEffect, useState, useCallback } from 'react'
+import { useAccount, useChainId, useSwitchChain } from 'wagmi'
+import { AlertCircle, Loader2, Check } from 'lucide-react'
 import {
   REQUIRED_CHAIN_ID,
   REQUIRED_CHAIN_NAME,
 } from '@/lib/wagmi'
 
+type SwitchState = 'idle' | 'switching' | 'success' | 'error'
+
 export function NetworkChecker() {
   const { isConnected } = useAccount()
   const chainId = useChainId()
+  const { switchChain, isPending, isSuccess, isError } = useSwitchChain()
   const [showWarning, setShowWarning] = useState(false)
+  const [switchState, setSwitchState] = useState<SwitchState>('idle')
+  const [autoSwitchAttempted, setAutoSwitchAttempted] = useState(false)
 
+  // Check if on wrong chain
+  const isWrongChain = isConnected && chainId && chainId !== REQUIRED_CHAIN_ID
+
+  // Update switch state based on wagmi hooks
   useEffect(() => {
-    if (isConnected && chainId && chainId !== REQUIRED_CHAIN_ID) {
+    if (isPending) {
+      setSwitchState('switching')
+    } else if (isSuccess) {
+      setSwitchState('success')
+      // Hide after success
+      setTimeout(() => {
+        setShowWarning(false)
+        setSwitchState('idle')
+      }, 1500)
+    } else if (isError) {
+      setSwitchState('error')
+    }
+  }, [isPending, isSuccess, isError])
+
+  // Auto-attempt switch when on wrong chain (only once per connection)
+  useEffect(() => {
+    if (isWrongChain && !autoSwitchAttempted && switchChain) {
+      setAutoSwitchAttempted(true)
+      setShowWarning(true)
+
+      // Auto-switch with a small delay to let the user see what's happening
+      const timer = setTimeout(() => {
+        try {
+          switchChain({ chainId: REQUIRED_CHAIN_ID })
+        } catch (error) {
+          console.error('Auto-switch failed:', error)
+        }
+      }, 500)
+
+      return () => clearTimeout(timer)
+    }
+  }, [isWrongChain, autoSwitchAttempted, switchChain])
+
+  // Reset auto-switch flag when chain changes correctly
+  useEffect(() => {
+    if (!isWrongChain) {
+      setAutoSwitchAttempted(false)
+    }
+  }, [isWrongChain])
+
+  // Show warning when on wrong chain
+  useEffect(() => {
+    if (isWrongChain) {
       setShowWarning(true)
     } else {
       setShowWarning(false)
     }
-  }, [isConnected, chainId])
+  }, [isWrongChain])
 
-  if (!isConnected || !showWarning) {
+  // Handle manual switch
+  const handleSwitch = useCallback(() => {
+    if (switchChain && switchState !== 'switching') {
+      setSwitchState('switching')
+      try {
+        switchChain({ chainId: REQUIRED_CHAIN_ID })
+      } catch (error) {
+        console.error('Switch failed:', error)
+        setSwitchState('error')
+      }
+    }
+  }, [switchChain, switchState])
+
+  if (!showWarning) {
     return null
   }
 
   return (
-    <div className="fixed top-16 left-0 right-0 z-50 mx-auto max-w-4xl px-4 sm:top-20">
-      <div className="rounded-lg border border-yellow-500/50 bg-yellow-500/10 p-4 backdrop-blur-sm">
+    <div className="fixed top-16 left-0 right-0 z-50 mx-auto max-w-md px-4 sm:top-20 animate-in slide-in-from-top-2 duration-300">
+      <div className="rounded-xl border border-brand-green/30 bg-brand-green/10 p-4 backdrop-blur-sm shadow-lg">
         <div className="flex items-center gap-3">
-          <AlertCircle className="h-5 w-5 flex-shrink-0 text-yellow-400" />
-          <div className="flex-1">
-            <p className="text-sm text-yellow-400">
-              Please open your wallet on <span className="font-mono font-semibold">{REQUIRED_CHAIN_NAME}</span> and connect
-            </p>
+          {switchState === 'switching' ? (
+            <Loader2 className="h-5 w-5 flex-shrink-0 text-brand-green animate-spin" />
+          ) : switchState === 'success' ? (
+            <Check className="h-5 w-5 flex-shrink-0 text-brand-green" />
+          ) : (
+            <AlertCircle className="h-5 w-5 flex-shrink-0 text-brand-green" />
+          )}
+          <div className="flex-1 min-w-0">
+            {switchState === 'switching' ? (
+              <p className="text-sm text-brand-green font-medium">
+                Switching to {REQUIRED_CHAIN_NAME}...
+              </p>
+            ) : switchState === 'success' ? (
+              <p className="text-sm text-brand-green font-medium">
+                Connected to {REQUIRED_CHAIN_NAME}
+              </p>
+            ) : switchState === 'error' ? (
+              <>
+                <p className="text-sm text-brand-green font-medium">
+                  Switch failed
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Please approve in your wallet
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-brand-green font-medium">
+                  Wrong Network
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Please switch to {REQUIRED_CHAIN_NAME}
+                </p>
+              </>
+            )}
           </div>
+          {(switchState === 'idle' || switchState === 'error') && (
+            <button
+              onClick={handleSwitch}
+              className="flex-shrink-0 px-3 py-1.5 text-xs font-medium bg-brand-green text-black rounded-lg hover:bg-[#4a9a26] transition-colors"
+            >
+              Switch
+            </button>
+          )}
         </div>
       </div>
     </div>
   )
 }
-

--- a/components/wallet/WalletConnect.tsx
+++ b/components/wallet/WalletConnect.tsx
@@ -1,24 +1,34 @@
 'use client'
 
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useCallback } from 'react'
 import { useAccount, useChainId, useDisconnect, useConnect } from 'wagmi'
 import { ConnectButton } from '@rainbow-me/rainbowkit'
-import { Wallet, LogOut, ChevronDown } from 'lucide-react'
+import { useSignIn } from '@farcaster/auth-kit'
+import { Wallet, LogOut, ChevronDown, X } from 'lucide-react'
 import { REQUIRED_CHAIN_ID } from '@/lib/wagmi'
 import { Button } from '@/components/ui/button'
+import { isFarcaster } from '@/lib/farcaster-detection'
+import { AuthKitProvider } from '@/components/auth/AuthKitProvider'
+
+// Farcaster miniapp URL for redirect after authentication
+const FARCASTER_MINIAPP_URL =
+  process.env.NEXT_PUBLIC_FARCASTER_MINIAPP_URL ||
+  'https://farcaster.xyz/miniapps/SfsGBDcHpuSA/decleanup-rewards'
 
 /**
- * WalletConnect component using RainbowKit
- * 
+ * WalletConnect component using RainbowKit + Farcaster Auth
+ *
  * Features:
  * - Custom styled button matching brand design (green with black text)
- * - Beautiful wallet connection UI via RainbowKit modals
+ * - Shows modal with Farcaster SIWF + wallet options on web
+ * - Direct wallet connection in Farcaster environment
  * - Automatic chain switching via RainbowKit
- * - Network validation display
  */
 export function WalletConnect() {
   const [mounted, setMounted] = useState(false)
   const [forceUpdate, setForceUpdate] = useState(0)
+  const [showLoginModal, setShowLoginModal] = useState(false)
+  const [isInFarcaster, setIsInFarcaster] = useState(false)
   const { isConnected, connector, address } = useAccount()
   const chainId = useChainId()
   const { disconnect } = useDisconnect()
@@ -29,14 +39,15 @@ export function WalletConnect() {
   // Initialize on mount
   useEffect(() => {
     setMounted(true)
-    
+    setIsInFarcaster(isFarcaster())
+
     // Log connector status for debugging
-    const isFarcasterEnv = 
+    const isFarcasterEnv =
       typeof window !== 'undefined' && (
         window.location.search.includes('fc_wallet=1') ||
         (window as any).farcaster?.sdk !== undefined
       )
-    
+
     if (isFarcasterEnv) {
       console.log('🔵 Farcaster environment detected in WalletConnect')
       console.log('Available connectors:', connectors.map(c => ({
@@ -45,18 +56,18 @@ export function WalletConnect() {
         ready: c.ready,
         type: c.type,
       })))
-      
+
       const farcasterConnector = connectors.find(c => {
         const name = c.name.toLowerCase()
         const id = c.id?.toLowerCase() || ''
-        return name.includes('farcaster') || 
-               name.includes('frame') || 
+        return name.includes('farcaster') ||
+               name.includes('frame') ||
                name.includes('miniapp') ||
-               id.includes('farcaster') || 
-               id.includes('frame') || 
+               id.includes('farcaster') ||
+               id.includes('frame') ||
                id.includes('miniapp')
       })
-      
+
       if (farcasterConnector) {
         console.log('✅ Farcaster connector found:', {
           id: farcasterConnector.id,
@@ -69,12 +80,19 @@ export function WalletConnect() {
     }
   }, [connectors])
 
+  // Close modal when connected
+  useEffect(() => {
+    if (isConnected && address) {
+      setShowLoginModal(false)
+    }
+  }, [isConnected, address])
+
   // Monitor connection state changes and force UI update when WalletConnect connects
   useEffect(() => {
     // Detect when connection state changes from disconnected to connected
     const justConnected = !previousConnectedRef.current && isConnected && address
     const addressChanged = previousAddressRef.current !== address && isConnected && address
-    
+
     if (justConnected || addressChanged) {
       console.log('Wallet connection detected:', {
         connector: connector?.name,
@@ -84,17 +102,16 @@ export function WalletConnect() {
         justConnected,
         addressChanged,
       })
-      
+
       // Force UI update by changing a state value
-      // This ensures RainbowKit modal detects the connection and updates UI
       setForceUpdate(prev => prev + 1)
-      
-      // Small delay to ensure state propagates, then force another update
+
+      // Small delay to ensure state propagates
       setTimeout(() => {
         setForceUpdate(prev => prev + 1)
       }, 100)
     }
-    
+
     // Update refs for next comparison
     previousConnectedRef.current = isConnected
     previousAddressRef.current = address
@@ -109,292 +126,87 @@ export function WalletConnect() {
     )
   }
 
-  // Use RainbowKit's ConnectButton.Custom to match brand design
-  // Add key prop that changes on connection to force re-render when WalletConnect connects
+  // Store openConnectModal ref for use outside render prop
+  const [openConnectModalFn, setOpenConnectModalFn] = useState<(() => void) | null>(null)
+
   return (
-    <div className="flex flex-col items-end gap-1" key={`wallet-connect-${forceUpdate}-${isConnected}-${address}`}>
-      <ConnectButton.Custom>
-        {({
-          account,
-          chain,
-          openAccountModal,
-          openChainModal,
-          openConnectModal,
-          authenticationStatus,
-          mounted: rainbowKitMounted,
-        }) => {
-          const ready = rainbowKitMounted && authenticationStatus !== 'loading'
-          const connected =
-            ready &&
-            account &&
-            chain &&
-            (!authenticationStatus || authenticationStatus === 'authenticated')
+    <>
+      {/* Login Modal - Rendered outside header for proper centering */}
+      {showLoginModal && openConnectModalFn && (
+        <AuthKitProvider>
+          <LoginModal
+            onClose={() => setShowLoginModal(false)}
+            onOpenWalletModal={() => {
+              setShowLoginModal(false)
+              openConnectModalFn()
+            }}
+          />
+        </AuthKitProvider>
+      )}
 
-          // Show loading state
-          if (!ready) {
-            return (
-              <div className="flex items-center gap-2">
-                <div className="h-10 w-32 animate-pulse rounded-lg bg-gray-700" />
-              </div>
-            )
-          }
-
-          // Not connected - show connect button
-          if (!connected) {
-            const handleConnect = (e: React.MouseEvent) => {
-              e.preventDefault()
-              e.stopPropagation()
-              
-              // Detect mobile browsers
-              const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
-              const isIOSSafari = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream
-              
-              // Check if we have ready connectors first
-              const readyConnectors = connectors.filter(c => c.ready)
-              const hasReadyConnectors = readyConnectors.length > 0
-              
-              console.log('🔌 Connect button clicked:', {
-                isMobile,
-                isIOSSafari,
-                readyConnectors: readyConnectors.length,
-                hasModal: !!openConnectModal,
-              })
-              
-              // On mobile, prefer direct connect if connectors are ready
-              // RainbowKit modal works on mobile, but direct connect is more reliable
-              if (isMobile && hasReadyConnectors) {
-                console.log('Mobile with ready connectors: using direct connect')
-                handleDirectConnect()
-                return
-              }
-              
-              // Try RainbowKit modal first (works well on desktop and some mobile browsers)
-              if (openConnectModal && typeof openConnectModal === 'function') {
-                try {
-                  console.log('Opening RainbowKit connect modal...')
-                  openConnectModal()
-                  // On mobile, also set up a fallback in case modal doesn't work
-                  if (isMobile) {
-                    setTimeout(() => {
-                      // Check if connection happened after modal opened
-                      // If not, try direct connect as fallback
-                      if (!isConnected) {
-                        console.log('Modal opened but no connection detected, will try direct connect if user cancels')
-                      }
-                    }, 2000)
-                  }
-                } catch (error) {
-                  console.warn('RainbowKit modal failed:', error)
-                  // Fallback: Try connecting directly
-                  handleDirectConnect()
-                }
-              } else {
-                // Fallback if modal function not available
-                console.log('Modal function not available, using direct connect')
-                handleDirectConnect()
-              }
+      <div className="flex flex-col items-end gap-1" key={`wallet-connect-${forceUpdate}-${isConnected}-${address}`}>
+        <ConnectButton.Custom>
+          {({
+            account,
+            chain,
+            openAccountModal,
+            openChainModal,
+            openConnectModal,
+            authenticationStatus,
+            mounted: rainbowKitMounted,
+          }) => {
+            // Store openConnectModal for use outside this render prop
+            if (openConnectModal && openConnectModalFn !== openConnectModal) {
+              // Use setTimeout to avoid state update during render
+              setTimeout(() => setOpenConnectModalFn(() => openConnectModal), 0)
             }
 
-            const handleDirectConnect = async () => {
-              // CRITICAL: Check for Farcaster environment FIRST
-              // In Farcaster, we MUST use the Farcaster connector, not injected wallets
-              const isFarcasterEnv = 
-                typeof window !== 'undefined' && (
-                  window.location.search.includes('fc_wallet=1') ||
-                  (window as any).farcaster?.sdk !== undefined
-                )
-              
-              // Detect mobile browsers (iOS Safari, Chrome Mobile, etc.)
-              const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
-              const isIOSSafari = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream
-              
-              // Check for injected wallet (window.ethereum) - but NOT in Farcaster
-              // On mobile, this might not be available immediately
-              const hasInjectedWallet = !isFarcasterEnv && typeof window !== 'undefined' && 
-                                       ((window as any).ethereum || (window as any).web3)
-              
-              console.log('🔍 Mobile wallet detection:', {
-                isMobile,
-                isIOSSafari,
-                isFarcasterEnv,
-                hasInjectedWallet,
-                totalConnectors: connectors.length,
-                readyConnectors: connectors.filter(c => c.ready).length,
-                connectorDetails: connectors.map(c => ({
-                  id: c.id,
-                  name: c.name,
-                  ready: c.ready,
-                  type: c.type,
-                })),
-              })
-              
-              let availableConnectors = connectors.filter(c => c.ready)
-              let connectorToUse
-              
-              // PRIORITY 1: If in Farcaster environment, MUST use Farcaster connector
-              if (isFarcasterEnv) {
-                console.log('🔵 Farcaster environment detected, looking for Farcaster connector...')
-                
-                // Find Farcaster connector
-                const farcasterConnector = connectors.find(c => {
-                  const name = c.name.toLowerCase()
-                  const id = c.id?.toLowerCase() || ''
-                  return name.includes('farcaster') || 
-                         name.includes('frame') || 
-                         name.includes('miniapp') ||
-                         id.includes('farcaster') || 
-                         id.includes('frame') || 
-                         id.includes('miniapp')
-                })
-                
-                if (farcasterConnector) {
-                  // Wait for Farcaster connector to be ready (it may take time to initialize)
-                  if (!farcasterConnector.ready) {
-                    console.log('⏳ Farcaster connector not ready yet, waiting...')
-                    // Wait up to 3 seconds for Farcaster connector to be ready
-                    for (let attempt = 0; attempt < 6; attempt++) {
-                      await new Promise(resolve => setTimeout(resolve, 500))
-                      if (farcasterConnector.ready) {
-                        console.log(`✅ Farcaster connector ready after ${(attempt + 1) * 500}ms`)
-                        break
-                      }
-                    }
-                  }
-                  
-                  if (farcasterConnector.ready) {
-                    connectorToUse = farcasterConnector
-                    console.log('✅ Using Farcaster connector:', farcasterConnector.name)
-                  } else {
-                    console.warn('⚠️ Farcaster connector not ready after waiting')
-                    alert('Farcaster wallet is not ready. Please wait a moment and try again.')
-                    return
-                  }
-                } else {
-                  console.error('❌ Farcaster environment detected but no Farcaster connector found!')
-                  alert('Farcaster wallet connector not available. Please refresh the page.')
+            const ready = rainbowKitMounted && authenticationStatus !== 'loading'
+            const connected =
+              ready &&
+              account &&
+              chain &&
+              (!authenticationStatus || authenticationStatus === 'authenticated')
+
+            // Show loading state
+            if (!ready) {
+              return (
+                <div className="flex items-center gap-2">
+                  <div className="h-10 w-32 animate-pulse rounded-lg bg-gray-700" />
+                </div>
+              )
+            }
+
+            // Not connected - show connect button
+            if (!connected) {
+              const handleConnect = (e: React.MouseEvent) => {
+                e.preventDefault()
+                e.stopPropagation()
+
+                // In Farcaster, use direct wallet connection
+                if (isInFarcaster) {
+                  openConnectModal()
                   return
                 }
-              } else {
-                // NOT in Farcaster - use standard wallet connection logic
-                // CRITICAL: On mobile, connectors take longer to initialize
-                // Wait for connectors to become ready, especially on mobile
-                if (availableConnectors.length === 0) {
-                  console.log('⏳ No ready connectors found, waiting for initialization...')
-                  // Wait longer on mobile (up to 5 seconds with retries)
-                  const maxAttempts = isMobile ? 10 : 6
-                  const delay = isMobile ? 500 : 300
-                  
-                  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-                    await new Promise(resolve => setTimeout(resolve, delay))
-                    availableConnectors = connectors.filter(c => c.ready)
-                    console.log(`Attempt ${attempt + 1}/${maxAttempts}: ${availableConnectors.length} ready connectors`, {
-                      connectors: availableConnectors.map(c => ({ id: c.id, name: c.name, ready: c.ready })),
-                    })
-                    if (availableConnectors.length > 0) {
-                      console.log(`✅ Connectors ready after ${(attempt + 1) * delay}ms`)
-                      break
-                    }
-                  }
-                }
-                
-                // If still no connectors, check if we have injected wallet
-                // On mobile Safari, injected wallets might not show up as connectors immediately
-                if (availableConnectors.length === 0 && hasInjectedWallet) {
-                  console.log('⚠️ No ready connectors but injected wallet detected, waiting a bit more...')
-                  // Give it one more second for mobile wallets
-                  await new Promise(resolve => setTimeout(resolve, isMobile ? 1000 : 500))
-                  availableConnectors = connectors.filter(c => c.ready)
-                }
-                
-                if (availableConnectors.length > 0) {
-                  // For iOS Safari, prefer injected/MetaMask over WalletConnect (WalletConnect has issues on iOS)
-                  if (isIOSSafari) {
-                    // iOS Safari: Prefer MetaMask/injected, avoid WalletConnect
-                    connectorToUse = availableConnectors.find(
-                      c => (c.id === 'metaMask' || c.id === 'injected' || c.name.toLowerCase().includes('metamask')) &&
-                           !c.id.includes('walletConnect') && !c.name.toLowerCase().includes('walletconnect')
-                    ) || availableConnectors.find(c => !c.id.includes('walletConnect'))
-                    
-                    if (connectorToUse) {
-                      console.log('✅ iOS Safari detected, using connector:', connectorToUse.name)
-                    }
-                  } else if (isMobile) {
-                    // Other mobile browsers: Prefer MetaMask or injected wallet, avoid WalletConnect
-                    connectorToUse = availableConnectors.find(
-                      c => (c.id === 'metaMask' || c.id === 'injected' || c.name.toLowerCase().includes('metamask')) &&
-                           !c.id.includes('walletConnect')
-                    ) || availableConnectors.find(c => !c.id.includes('walletConnect')) || availableConnectors[0]
-                    console.log('✅ Mobile browser detected, using connector:', connectorToUse?.name || 'first available')
-                  } else {
-                    // Desktop browsers: Prefer MetaMask or injected wallet
-                    connectorToUse = availableConnectors.find(
-                      c => c.id === 'metaMask' || c.id === 'injected' || c.name.toLowerCase().includes('metamask')
-                    ) || availableConnectors[0]
-                    console.log('✅ Desktop browser, using connector:', connectorToUse?.name || 'first available')
-                  }
-                } else if (hasInjectedWallet) {
-                  // Last resort: try to find injected connector even if not ready
-                  // On mobile, sometimes connectors aren't marked as ready but still work
-                  const injectedConnector = connectors.find(
-                    c => c.id === 'injected' || c.id === 'metaMask' || c.name.toLowerCase().includes('metamask')
-                  )
-                  if (injectedConnector) {
-                    console.log('⚠️ Using injected connector even though not marked as ready:', injectedConnector.name)
-                    connectorToUse = injectedConnector
-                  }
-                }
-              }
-              
-              if (!connectorToUse) {
-                console.error('❌ No connector available:', {
-                  isFarcasterEnv,
-                  hasInjectedWallet,
-                  availableConnectors: availableConnectors.length,
-                  allConnectors: connectors.map(c => ({ id: c.id, name: c.name, ready: c.ready })),
-                })
-                
-                if (isFarcasterEnv) {
-                  alert('Farcaster wallet is not ready. Please wait a moment and try again.')
-                } else if (hasInjectedWallet) {
-                  alert('Wallet detected but not ready. Please wait a moment and try again, or ensure your wallet is unlocked.')
-                } else if (isMobile) {
-                  alert('No wallets found. On mobile, please:\n\n1. Install MetaMask or another Web3 wallet app\n2. Open the wallet app and unlock it\n3. Return to this page and try again\n\nOr use the "Connect Wallet" button to scan a QR code with WalletConnect.')
-                } else {
-                  alert('No wallets available. Please install MetaMask or another Web3 wallet to connect.')
-                }
-                return
-              }
-              
-              try {
-                await connect({ connector: connectorToUse })
-              } catch (connectError: any) {
-                console.error('Direct connect failed:', connectError)
-                const errorMsg = connectError?.message || String(connectError || 'Unknown error')
-                
-                // Don't show alert for user rejections
-                if (!errorMsg.toLowerCase().includes('rejected') && 
-                    !errorMsg.toLowerCase().includes('denied') &&
-                    !errorMsg.toLowerCase().includes('user cancelled')) {
-                  // Last resort: show alert
-                  alert('Connection failed. Please ensure your wallet is unlocked and try again.')
-                }
-              }
-            }
 
-            return (
-              <div className="flex flex-col items-end gap-1">
-                <Button
-                  size="sm"
-                  onClick={handleConnect}
-                  disabled={isPending}
-                  className="gap-2 bg-brand-green text-black hover:bg-[#4a9a26] text-xs sm:text-sm disabled:opacity-50"
-                >
-                  <Wallet className="h-3 w-3 sm:h-4 sm:w-4" />
-                  <span>{isPending ? 'Connecting...' : 'Connect Wallet'}</span>
-                </Button>
-              </div>
-            )
-          }
+                // On web, show our custom modal with Farcaster option
+                setShowLoginModal(true)
+              }
+
+              return (
+                <div className="flex flex-col items-end gap-1">
+                  <Button
+                    size="sm"
+                    onClick={handleConnect}
+                    disabled={isPending}
+                    className="gap-2 bg-brand-green text-black hover:bg-[#4a9a26] text-xs sm:text-sm disabled:opacity-50"
+                  >
+                    <Wallet className="h-3 w-3 sm:h-4 sm:w-4" />
+                    <span>{isPending ? 'Connecting...' : 'Connect Wallet'}</span>
+                  </Button>
+                </div>
+              )
+            }
 
           // Wrong network - show network switch button
           if (chain.unsupported || chain.id !== REQUIRED_CHAIN_ID) {
@@ -413,7 +225,7 @@ export function WalletConnect() {
           // Connected - show account button
           return (
             <div className="flex items-center gap-2">
-              <div 
+              <div
                 className="flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-900 px-2 py-1.5 sm:px-3 sm:py-2 cursor-pointer hover:border-brand-green transition-colors"
                 onClick={openAccountModal}
                 title={`Click to view account details or disconnect. Full address: ${account.address}`}
@@ -432,7 +244,6 @@ export function WalletConnect() {
                     console.log('Wallet disconnected successfully')
                   } catch (error) {
                     console.error('Error disconnecting wallet:', error)
-                    // Fallback: try opening account modal which has disconnect option
                     openAccountModal()
                   }
                 }}
@@ -444,14 +255,190 @@ export function WalletConnect() {
             </div>
           )
         }}
-      </ConnectButton.Custom>
-      
-      {/* Network info */}
-      <div className="flex flex-col items-end gap-0.5 w-full">
-        <span className="text-[10px] text-muted-foreground/70 text-right">
-          Use, when on web app. Base Sepolia
-        </span>
+        </ConnectButton.Custom>
+
+        {/* Network info */}
+        <div className="flex flex-col items-end gap-0.5 w-full">
+          <span className="text-[10px] text-muted-foreground/70 text-right">
+            Base Sepolia
+          </span>
+        </div>
+      </div>
+    </>
+  )
+}
+
+// Login Modal with Farcaster SIWF + Wallet options
+function LoginModal({
+  onClose,
+  onOpenWalletModal,
+}: {
+  onClose: () => void
+  onOpenWalletModal: () => void
+}) {
+  const [showQR, setShowQR] = useState(false)
+
+  const {
+    signIn,
+    connect,
+    url,
+    isSuccess,
+    isError,
+    error,
+    channelToken,
+  } = useSignIn({
+    onSuccess: (data) => {
+      console.log('[LoginModal] SIWF success:', data)
+      // Redirect to Farcaster miniapp after successful auth
+      const redirectUrl = data.custody
+        ? `${FARCASTER_MINIAPP_URL}?ref=${data.custody}`
+        : FARCASTER_MINIAPP_URL
+      window.location.href = redirectUrl
+    },
+    onError: (err) => {
+      console.error('[LoginModal] SIWF error:', err)
+    },
+  })
+
+  const handleFarcasterLogin = useCallback(async () => {
+    console.log('[LoginModal] Starting Farcaster login...')
+    try {
+      if (!channelToken) {
+        await connect()
+      }
+      await signIn()
+      setShowQR(true)
+    } catch (err) {
+      console.error('[LoginModal] Error:', err)
+    }
+  }, [connect, signIn, channelToken])
+
+  // Show QR code if URL is available
+  if (showQR && url && !isSuccess) {
+    return (
+      <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+        <div className="relative max-w-sm w-full bg-card border border-border rounded-2xl shadow-2xl p-6">
+          <button
+            onClick={() => { setShowQR(false); onClose(); }}
+            className="absolute top-4 right-4 p-1 text-muted-foreground hover:text-foreground"
+          >
+            <X className="w-5 h-5" />
+          </button>
+
+          <div className="text-center mb-4">
+            <h2 className="text-lg font-bold text-foreground">Scan with Warpcast</h2>
+            <p className="text-sm text-muted-foreground">
+              Open Warpcast and scan this QR code
+            </p>
+          </div>
+
+          <div className="flex justify-center mb-4">
+            <div className="p-4 bg-white rounded-xl">
+              <img
+                src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(url)}`}
+                alt="Sign in with Farcaster"
+                className="w-48 h-48"
+              />
+            </div>
+          </div>
+
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block w-full py-3 text-center bg-brand-green hover:bg-[#4a9a26] text-black font-medium rounded-xl transition-colors"
+          >
+            Open in Warpcast
+          </a>
+        </div>
+      </div>
+    )
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+        <div className="relative max-w-sm w-full bg-card border border-border rounded-2xl shadow-2xl p-6">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 p-1 text-muted-foreground hover:text-foreground"
+          >
+            <X className="w-5 h-5" />
+          </button>
+          <p className="text-center text-red-500 mb-4">
+            Sign in failed{error?.message ? `: ${error.message}` : ''}
+          </p>
+          <button
+            onClick={handleFarcasterLogin}
+            className="w-full py-3 bg-brand-green hover:bg-[#4a9a26] text-black font-medium rounded-xl"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // Main modal with options
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+      <div className="relative max-w-sm w-full bg-card border border-border rounded-2xl shadow-2xl p-6">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 p-1 text-muted-foreground hover:text-foreground"
+        >
+          <X className="w-5 h-5" />
+        </button>
+
+        <div className="text-center mb-6">
+          <h2 className="text-lg font-bold text-foreground">Connect</h2>
+          <p className="text-sm text-muted-foreground">
+            Choose how to connect
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          {/* Farcaster option */}
+          <button
+            onClick={handleFarcasterLogin}
+            className="w-full flex items-center gap-3 p-4 bg-[#855DCD] hover:bg-[#7349b8] text-white rounded-xl transition-colors"
+          >
+            <div className="w-10 h-10 bg-white/20 rounded-lg flex items-center justify-center">
+              <FarcasterIcon className="w-6 h-6" />
+            </div>
+            <div className="text-left">
+              <p className="font-medium">Sign in with Farcaster</p>
+              <p className="text-xs text-white/70">Scan QR with Warpcast</p>
+            </div>
+          </button>
+
+          {/* Wallet option */}
+          <button
+            onClick={onOpenWalletModal}
+            className="w-full flex items-center gap-3 p-4 bg-muted hover:bg-muted/80 text-foreground rounded-xl transition-colors"
+          >
+            <div className="w-10 h-10 bg-brand-green/20 rounded-lg flex items-center justify-center">
+              <Wallet className="w-6 h-6 text-brand-green" />
+            </div>
+            <div className="text-left">
+              <p className="font-medium">Connect Wallet</p>
+              <p className="text-xs text-muted-foreground">MetaMask, WalletConnect, etc.</p>
+            </div>
+          </button>
+        </div>
       </div>
     </div>
+  )
+}
+
+// Farcaster icon
+function FarcasterIcon({ className = 'w-5 h-5' }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 1000 1000" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M257.778 155.556H742.222V844.444H671.111V528.889H670.414C662.554 441.677 589.258 373.333 500 373.333C410.742 373.333 337.446 441.677 329.586 528.889H328.889V844.444H257.778V155.556Z" fill="currentColor"/>
+      <path d="M128.889 253.333L157.778 351.111H182.222V746.667C169.949 746.667 160 756.616 160 768.889V795.556H155.556C143.283 795.556 133.333 805.505 133.333 817.778V844.444H382.222V817.778C382.222 805.505 372.273 795.556 360 795.556H355.556V768.889C355.556 756.616 345.606 746.667 333.333 746.667H306.667V253.333H128.889Z" fill="currentColor"/>
+      <path d="M675.556 746.667C663.283 746.667 653.333 756.616 653.333 768.889V795.556H648.889C636.616 795.556 626.667 805.505 626.667 817.778V844.444H875.556V817.778C875.556 805.505 865.606 795.556 853.333 795.556H848.889V768.889C848.889 756.616 838.94 746.667 826.667 746.667V351.111H851.111L880 253.333H702.222V746.667H675.556Z" fill="currentColor"/>
+    </svg>
   )
 }

--- a/lib/farcaster.ts
+++ b/lib/farcaster.ts
@@ -258,34 +258,6 @@ export const shareToX = async (text: string, url?: string): Promise<boolean> => 
 // Share a cast (post) on Farcaster
 export const shareCast = async (text: string, url?: string): Promise<boolean> => {
   try {
-    // IMPORTANT: Do NOT use the Web Share API here.
-    // On mobile (including inside Warpcast), navigator.share will only share a plain
-    // link + text and will NOT create an embed with a pressable miniapp frame.
-    // To get a preview + frame, we must always use the Warpcast compose URL with
-    // ?text=...&embeds[]=...
-
-    // Build Warpcast compose URL with pre-filled text and embed
-    // Warpcast compose URL format: https://warpcast.com/~/compose?text=...&embeds[]=...
-    //
-    // IMPORTANT:
-    // - For referral links that already use the Farcaster miniapp URL
-    //   (https://farcaster.xyz/miniapps/.../decleanup-rewards?ref=0x...),
-    //   we should pass that exact URL as the embed so Warpcast shows the
-    //   mini app preview + pressable frame.
-    // - Using an intermediate /share page can result in a plain link with
-    //   no miniapp frame, especially on mobile.
-    let farcasterUrl: string
-    if (url) {
-      const embedUrl = url
-      // Include both text and embed URL
-      farcasterUrl = `https://warpcast.com/~/compose?text=${encodeURIComponent(
-        text
-      )}&embeds[]=${encodeURIComponent(embedUrl)}`
-    } else {
-      // Just text, no embed
-      farcasterUrl = `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}`
-    }
-
     // Check if we are in Farcaster context
     let inFarcaster = false
     try {
@@ -295,42 +267,81 @@ export const shareCast = async (text: string, url?: string): Promise<boolean> =>
       inFarcaster = false
     }
 
+    // INSIDE FARCASTER MINIAPP: Use SDK's composeCast action directly
+    // This is the correct way to open the composer from within a miniapp
     if (inFarcaster) {
       try {
-        // In Farcaster, use SDK's openUrl
-        await openUrl(farcasterUrl)
-        return true
-      } catch (openUrlError) {
-        console.warn('openUrl failed in Farcaster context, trying window.open:', openUrlError)
-        // Fallback to window.open even in Farcaster context
+        console.log('[shareCast] In Farcaster, using sdk.actions.composeCast...')
+
+        // Build embeds array if URL is provided
+        const embeds = url ? [url] : undefined
+
+        // Use the SDK's composeCast action - this opens Warpcast's native composer
+        if (sdk.actions && typeof sdk.actions.composeCast === 'function') {
+          await sdk.actions.composeCast({
+            text,
+            embeds,
+          })
+          console.log('[shareCast] composeCast called successfully')
+          return true
+        } else if (sdk.actions && typeof (sdk.actions as any).openComposer === 'function') {
+          // Fallback to openComposer if composeCast doesn't exist
+          await (sdk.actions as any).openComposer({
+            text,
+            embeds,
+          })
+          console.log('[shareCast] openComposer called successfully')
+          return true
+        } else {
+          console.warn('[shareCast] composeCast/openComposer not available, falling back to openUrl')
+          // Fall back to openUrl with Warpcast compose URL
+          const farcasterUrl = url
+            ? `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}&embeds[]=${encodeURIComponent(url)}`
+            : `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}`
+          await openUrl(farcasterUrl)
+          return true
+        }
+      } catch (sdkError) {
+        console.error('[shareCast] SDK composeCast failed:', sdkError)
+        // Try openUrl as fallback
+        try {
+          const farcasterUrl = url
+            ? `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}&embeds[]=${encodeURIComponent(url)}`
+            : `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}`
+          await openUrl(farcasterUrl)
+          return true
+        } catch (openUrlError) {
+          console.warn('[shareCast] openUrl also failed:', openUrlError)
+        }
       }
     }
 
-    // For browser (not in Farcaster), open Warpcast compose in new tab
+    // OUTSIDE FARCASTER (browser): Open Warpcast compose URL in new tab
+    // Build Warpcast compose URL with pre-filled text and embed
+    const farcasterUrl = url
+      ? `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}&embeds[]=${encodeURIComponent(url)}`
+      : `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}`
+
     if (typeof window !== 'undefined') {
-      console.log('Opening Warpcast compose in browser:', farcasterUrl)
+      console.log('[shareCast] Opening Warpcast compose in browser:', farcasterUrl)
       try {
-        // Use window.open with noopener for security
         const newWindow = window.open(farcasterUrl, '_blank', 'noopener,noreferrer')
         if (newWindow) {
-          // Successfully opened
-          console.log('Successfully opened Warpcast compose window')
+          console.log('[shareCast] Successfully opened Warpcast compose window')
           return true
         } else {
-          // Popup blocked - fall through to clipboard
-          console.warn('Popup blocked by browser, falling back to clipboard')
+          console.warn('[shareCast] Popup blocked by browser')
           throw new Error('Popup blocked')
         }
       } catch (openError) {
-        console.error('window.open failed:', openError)
+        console.error('[shareCast] window.open failed:', openError)
         throw new Error('Failed to open share window')
       }
     }
 
-    // Last resort: copy to clipboard
     throw new Error('No sharing method available')
   } catch (error) {
-    console.error('Failed to share cast:', error)
+    console.error('[shareCast] Failed to share cast:', error)
     // Fallback: try to copy to clipboard
     try {
       const fullText = text + (url ? ` ${url}` : '')
@@ -340,34 +351,14 @@ export const shareCast = async (text: string, url?: string): Promise<boolean> =>
           alert('Share popup was blocked. Message copied to clipboard! Paste it into Warpcast to share.')
         }
         return true
-      } else {
-        throw new Error('Clipboard API not available')
       }
     } catch (clipboardError) {
-      console.error('Failed to copy to clipboard:', clipboardError)
+      console.error('[shareCast] Clipboard fallback failed:', clipboardError)
       if (typeof window !== 'undefined') {
-        // Show the text in an alert so user can copy manually
-        const shareText = `Failed to open share dialog. Please copy this manually:\n\n${text}${
-          url ? ` ${url}` : ''
-        }`
-        alert(shareText)
-        // Also try to select the text if possible
-        const textarea = document.createElement('textarea')
-        textarea.value = text + (url ? ` ${url}` : '')
-        textarea.style.position = 'fixed'
-        textarea.style.opacity = '0'
-        document.body.appendChild(textarea)
-        textarea.select()
-        try {
-          document.execCommand('copy')
-          document.body.removeChild(textarea)
-          alert('Text selected - press Ctrl+C (Cmd+C on Mac) to copy')
-        } catch (e) {
-          document.body.removeChild(textarea)
-        }
+        alert(`Failed to share. Please copy manually:\n\n${text}${url ? ` ${url}` : ''}`)
       }
-      return false
     }
+    return false
   }
 }
 

--- a/lib/wagmi.ts
+++ b/lib/wagmi.ts
@@ -80,11 +80,23 @@ const APP_ICON_URL =
 // Get WalletConnect project ID from environment
 const walletConnectProjectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
 
-// Validate WalletConnect Project ID - throw error on module load if missing
-if (!walletConnectProjectId) {
+// Warn if WalletConnect Project ID is missing (required for production, optional for local dev)
+const isDevMode = process.env.NODE_ENV === 'development'
+const hasValidProjectId = walletConnectProjectId &&
+  walletConnectProjectId !== 'YOUR_PROJECT_ID_HERE' &&
+  walletConnectProjectId.length > 10
+
+if (!hasValidProjectId && !isDevMode) {
   throw new Error(
     'WalletConnect Project ID is required. Set NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID. ' +
     'Get your Project ID at https://cloud.reown.com'
+  )
+}
+
+if (!hasValidProjectId && isDevMode) {
+  console.warn(
+    '[wagmi] WalletConnect Project ID not configured. ' +
+    'Some wallet features may be limited. Get your Project ID at https://cloud.reown.com'
   )
 }
 
@@ -110,6 +122,12 @@ export function getWagmiConfig() {
     return _config
   }
 
+  // Use a fallback project ID for development if not configured
+  // This allows local development without WalletConnect, but limits some features
+  const effectiveProjectId = hasValidProjectId
+    ? walletConnectProjectId!
+    : 'development-placeholder-id'
+
   // For SSR, create a minimal config that satisfies type requirements
   // This won't work for actual wallet operations, but prevents build errors
   if (typeof window === 'undefined') {
@@ -117,9 +135,9 @@ export function getWagmiConfig() {
     // Note: getDefaultWallets is still valid in v2 when you need custom connector logic
     const { connectors: defaultConnectors } = getDefaultWallets({
       appName: APP_NAME,
-      projectId: walletConnectProjectId!,
+      projectId: effectiveProjectId,
     })
-    
+
     return createConfig({
       chains: configuredChains,
       connectors: defaultConnectors,
@@ -136,7 +154,7 @@ export function getWagmiConfig() {
   // is still available and appropriate when you need conditional connectors (like Farcaster)
   const { connectors: defaultConnectors } = getDefaultWallets({
     appName: APP_NAME,
-    projectId: walletConnectProjectId!,
+    projectId: effectiveProjectId,
   })
 
   // CRITICAL: Check for Farcaster environment AFTER window is ready

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "decleanup-mini-app",
       "version": "0.1.0",
       "dependencies": {
+        "@farcaster/auth-kit": "^0.8.1",
         "@farcaster/miniapp-sdk": "^0.2.1",
         "@farcaster/miniapp-wagmi-connector": "^1.1.0",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -1441,6 +1442,33 @@
         "@noble/hashes": "1.4.0",
         "@scure/bip32": "1.4.0",
         "@scure/bip39": "1.3.0"
+      }
+    },
+    "node_modules/@farcaster/auth-client": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@farcaster/auth-client/-/auth-client-0.7.0.tgz",
+      "integrity": "sha512-WtQ/dNAlS8VXA73bMjlgdV49vuUJyoPJz6QfSj0rMbv3JFw3SrRDxP5d6fDQxFcYHiDsWCm6ZOe6X03DBNnbaA==",
+      "license": "MIT",
+      "dependencies": {
+        "neverthrow": "^6.1.0",
+        "viem": "^2.29.2"
+      }
+    },
+    "node_modules/@farcaster/auth-kit": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@farcaster/auth-kit/-/auth-kit-0.8.1.tgz",
+      "integrity": "sha512-n9/szpj9TZosOvUaxS66VOnpGJpK4mHGoiUqoiRaCCRgFvRSi+jFG0SxyY4S/HV+Dv/In3pN/Suy3CwpD9nPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@farcaster/auth-client": "^0.7.0",
+        "@vanilla-extract/css": "^1.14.0",
+        "ethers": "^6.14.0",
+        "qrcode": "^1.5.3",
+        "react-remove-scroll": "^2.5.7"
+      },
+      "peerDependencies": {
+        "react": ">= 17",
+        "react-dom": ">= 17"
       }
     },
     "node_modules/@farcaster/miniapp-core": {
@@ -4478,17 +4506,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-pay": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
@@ -4870,17 +4887,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-wallet": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
@@ -5212,17 +5218,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@resvg/resvg-wasm": {
@@ -9479,17 +9474,6 @@
         }
       }
     },
-    "node_modules/@walletconnect/utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
@@ -9564,6 +9548,12 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -12076,6 +12066,106 @@
       "license": "MIT",
       "dependencies": {
         "fast-safe-stringify": "^2.0.6"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/eventemitter2": {
@@ -15793,6 +15883,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neverthrow": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.2.2.tgz",
+      "integrity": "sha512-POR1FACqdK9jH0S2kRPzaZEvzT11wsOxLW520PQV/+vKi9dQe+hXq19EiOvYx7lSRaF5VB9lYGsPInynrnN05w==",
       "license": "MIT"
     },
     "node_modules/next": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "generate:metadata": "node scripts/generateImpactMetadata.js"
   },
   "dependencies": {
+    "@farcaster/auth-kit": "^0.8.1",
     "@farcaster/miniapp-sdk": "^0.2.1",
     "@farcaster/miniapp-wagmi-connector": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## Summary

- Add Sign In With Farcaster (SIWF) authentication for web users
- Add Farcaster login option to both header and main page "Log In" buttons
- Create notification prompt for Farcaster miniapp users (enables push notifications)
- Fix share/referral functionality to use `sdk.actions.composeCast()` in miniapp

## Changes

### New Components
- `SmartWalletConnect` - Unified login button with Farcaster + wallet options
- `AuthKitProvider` - Farcaster AuthKit configuration wrapper
- `FarcasterSignIn` - Standalone Farcaster login with QR code
- `WebRedirectPrompt` - Suggests web users to open in Farcaster
- `NotificationPrompt` - Prompts users to enable app notifications via `addFrame()`
- `/login` page - Dedicated login page with Farcaster options

### Updated Components
- `WalletConnect` - Header button now shows Farcaster + wallet modal on web
- `NetworkChecker` - Auto-switch network with improved UX and brand styling
- `lib/farcaster.ts` - Fixed `shareCast()` to use SDK's native `composeCast()`

### Key Features
- Single "Log In" / "Connect Wallet" button opens modal with:
  - Sign in with Farcaster (QR code for Warpcast)
  - Connect Wallet (MetaMask, WalletConnect, etc.)
- Auto-detects Farcaster environment for direct wallet connection
- Notification prompt appears once per session in Farcaster miniapp
- Brand green (#58B12F) styling throughout

## Test plan

- [ ] Test login flow on web browser (should show Farcaster + Wallet options)
- [ ] Test login in Farcaster miniapp (should connect directly)
- [ ] Test notification prompt appears in Farcaster miniapp
- [ ] Test share referral button works in Farcaster miniapp
- [ ] Test web redirect prompt appears on web (once per session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)